### PR TITLE
Update benchmark to use non-legacy template

### DIFF
--- a/openfaas/README.md
+++ b/openfaas/README.md
@@ -1,0 +1,6 @@
+## Readme
+
+```
+faas-cli template store pull golang-middlware
+```
+

--- a/openfaas/hello-openfaas.legacy.yml
+++ b/openfaas/hello-openfaas.legacy.yml
@@ -2,6 +2,6 @@ provider:
   name: openfaas
 functions:
   hello-openfaas:
-    lang: go
+    lang: golang-
     handler: ./hello-openfaas
     image: lreimer/hello-openfaas:latest

--- a/openfaas/hello-openfaas.legacy/handler.go
+++ b/openfaas/hello-openfaas.legacy/handler.go
@@ -1,0 +1,10 @@
+package function
+
+import (
+	"fmt"
+)
+
+// Handle a serverless request
+func Handle(req []byte) string {
+	return fmt.Sprintf("Hello from OpenFaas! %s", string(req))
+}

--- a/openfaas/hello-openfaas/handler.go
+++ b/openfaas/hello-openfaas/handler.go
@@ -2,9 +2,21 @@ package function
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 )
 
-// Handle a serverless request
-func Handle(req []byte) string {
-	return fmt.Sprintf("Hello from OpenFaas! %s", string(req))
+func Handle(w http.ResponseWriter, r *http.Request) {
+	var input []byte
+
+	if r.Body != nil {
+		defer r.Body.Close()
+
+		body, _ := ioutil.ReadAll(r.Body)
+
+		input = body
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(fmt.Sprintf("Hello world, input was: %s", string(input))))
 }

--- a/openfaas/stack.yml
+++ b/openfaas/stack.yml
@@ -1,0 +1,9 @@
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  hello-openfaas:
+    lang: golang-middleware
+    handler: ./hello-openfaas
+    image: lreimer/hello-openfaas:benchmark

--- a/openfaas/stack.yml
+++ b/openfaas/stack.yml
@@ -7,3 +7,6 @@ functions:
     lang: golang-middleware
     handler: ./hello-openfaas
     image: lreimer/hello-openfaas:benchmark
+    labels:
+      com.openfaas.scale.min: 5
+      com.openfaas.scale.max: 20


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

The original author appears not to have see the documentation
on performance testing and benchmarking with OpenFaaS. This commit
updates the example to perform at representative speed.

Ref:
https://docs.openfaas.com/architecture/performance/
